### PR TITLE
Adding support for Nacon REVOLUTION PRO PS4 CONTROLLER

### DIFF
--- a/system/usr/keylayout/Vendor_146b_Product_0d01.kl
+++ b/system/usr/keylayout/Vendor_146b_Product_0d01.kl
@@ -1,0 +1,46 @@
+# Copyright (C) 2011 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# Sony Dualshock 4
+#
+
+key 305   BUTTON_A			# Cross
+key 306   BUTTON_B			# Circle
+key 304   BUTTON_X			# Square
+key 307   BUTTON_Y			# Triangle
+key 308   BUTTON_L1			# L1
+key 309   BUTTON_R1			# R1
+key 310   BUTTON_L2			# L2
+key 311   BUTTON_R2			# R2
+key 312   BUTTON_SELECT		# Select / Share
+key 313   BUTTON_START		# Start / Options
+key 316   HOME				# PS Home
+key 314   BUTTON_THUMBL 	# L3
+key 315   BUTTON_THUMBR		# R3
+key 317   BACK				# Touchpad Press
+
+# Left and right stick.
+axis 0x00 X flat 0
+axis 0x01 Y flat 0
+axis 0x02 Z flat 0
+axis 0x05 RZ flat 0
+
+# Triggers.
+axis 0x09 GAS
+axis 0x0a BRAKE
+
+# Hat. 
+axis 0x10 HAT_X
+axis 0x11 HAT_Y


### PR DESCRIPTION
Same as the PS4 layout just different vendor and product ID