### PR TITLE
Xbox X|S One wireless 1914 variant

### DIFF
--- a/system/usr/keylayout/Vendor_045e_Product_0b13.kl
+++ b/system/usr/keylayout/Vendor_045e_Product_0b13.kl
@@ -1,0 +1,47 @@
+# Copyright (C) 2016 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# XBox X/S wireless controller, model # 1914, QAU-00002, bought early 2023
+#
+
+key 304   BUTTON_A
+key 305   BUTTON_B
+key 307   BUTTON_X
+key 308   BUTTON_Y
+key 310   BUTTON_L1
+key 311   BUTTON_R1
+key 314   BUTTON_SELECT # center left button with "overlapping windows" icon. Normally: BUTTON_SELECT
+key 315   BUTTON_START # center right button with "hamburger" icon. Normally: BUTTON_START
+key 316   BUTTON_MODE # big Xbox logo center top button. Normally: BUTTON_MODE
+key 167   BACK # center bottom button with an "eject" icon. Normally: ???
+key 317   BUTTON_THUMBL # normally: BUTTON_THUMBL
+key 318   BUTTON_THUMBR # normally: BUTTON_THUMBR
+
+# Left and right stick.
+# The reported value for flat is 128 out of a range from -32767 to 32768, which is absurd.
+# This confuses applications that rely on the flat value because the joystick actually
+# settles in a flat range of +/- 4096 or so.
+axis 0x00 X flat 4096
+axis 0x01 Y flat 4096
+axis 0x02 Z flat 4096
+axis 0x05 RZ flat 4096
+
+# Triggers.
+axis 0x09 LTRIGGER
+axis 0x0A RTRIGGER
+
+# Hat.
+axis 0x10 HAT_X
+axis 0x11 HAT_Y

--- a/system/usr/keylayout/Vendor_046d_Product_c211.kl
+++ b/system/usr/keylayout/Vendor_046d_Product_c211.kl
@@ -1,0 +1,51 @@
+# Copyright (C) 2016 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# Old Logitech WingMan RumblePad
+#
+
+# key 103   DPAD_UP
+# key 105   DPAD_LEFT
+# key 106   DPAD_RIGHT
+# key 108   DPAD_DOWN
+
+
+key 288   BUTTON_A
+key 289   BUTTON_B
+key 291   BUTTON_X
+key 292   BUTTON_Y
+key 294   BUTTON_L1
+key 295   BUTTON_R1
+key 297   MENU # Normally: BUTTON_L2
+key 298   HOME # Normally: BUTTON_R2
+key 296   BUTTON_START
+key 290   BUTTON_SELECT # Normally: BUTTON_C
+key 293   ESCAPE # Normally: BUTTON_Z
+
+# Left and right stick.
+# The reported value for flat is 128 out of a range from -32767 to 32768, which is absurd.
+# This confuses applications that rely on the flat value because the joystick actually
+# settles in a flat range of +/- 4096 or so.
+axis 0x00 X flat 4096 # OK
+axis 0x01 Y flat 4096 # OK
+axis 0x05 Z flat 4096 # OK
+axis 0x06 RZ flat 4096 # OK
+
+axis 0x02 THROTTLE flat 4096 # OK
+
+
+# This actually controls the DPAD
+axis 0x10 HAT_X
+axis 0x11 HAT_Y


### PR DESCRIPTION
I bought a recent Microsoft Xbox controller that was almost, but not completely, similar to Vendor_045e_Product_0b12.kl.
This one is version 0b13.
https://www.amazon.fr/dp/B087VMGP5G

I'm unsure of what keycode should be sent by the button between SELECT and START.
